### PR TITLE
Remove non-Crystal features, improve heredoc format

### DIFF
--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -928,17 +928,6 @@
 			"name": "constant.other.symbol.crystal.19syntax"
 		},
 		{
-			"begin": "^=begin",
-			"captures": [
-				{
-					"name": "punctuation.definition.comment.crystal"
-				}
-			],
-			"comment": "multiline comments",
-			"end": "^=end",
-			"name": "comment.block.documentation.crystal"
-		},
-		{
 			"captures": {
 				"1": {
 					"name": "punctuation.definition.comment.crystal"
@@ -948,30 +937,7 @@
 			"name": "comment.line.number-sign.crystal"
 		},
 		{
-			"begin": "^__END__\\n",
-			"captures": [
-				{
-					"name": "string.unquoted.program-block.crystal"
-				}
-			],
-			"comment": "__END__ marker",
-			"contentName": "text.plain",
-			"end": "(?=not)impossible",
-			"patterns": [
-				{
-					"begin": "(?=<?xml|<(?i:html\\b)|!DOCTYPE (?i:html\\b))",
-					"end": "(?=not)impossible",
-					"name": "text.html.embedded.crystal",
-					"patterns": [
-						{
-							"include": "text.html.basic"
-						}
-					]
-				}
-			]
-		},
-		{
-			"begin": "(?><<-(\"?)((?:[_\\w]+_|)HTML)\\b\\1)",
+			"begin": "(?><<-('?)((?:[_\\w]+_|)HTML)\\b\\1)",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -1002,7 +968,7 @@
 			]
 		},
 		{
-			"begin": "(?><<-(\"?)((?:[_\\w]+_|)SQL)\\b\\1)",
+			"begin": "(?><<-('?)((?:[_\\w]+_|)SQL)\\b\\1)",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -1033,7 +999,7 @@
 			]
 		},
 		{
-			"begin": "(?><<-(\"?)((?:[_\\w]+_|)CSS)\\b\\1)",
+			"begin": "(?><<-('?)((?:[_\\w]+_|)CSS)\\b\\1)",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -1064,7 +1030,7 @@
 			]
 		},
 		{
-			"begin": "(?><<-(\"?)((?:[_\\w]+_|)CPP)\\b\\1)",
+			"begin": "(?><<-('?)((?:[_\\w]+_|)CPP)\\b\\1)",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -1095,7 +1061,7 @@
 			]
 		},
 		{
-			"begin": "(?><<-(\"?)((?:[_\\w]+_|)C)\\b\\1)",
+			"begin": "(?><<-('?)((?:[_\\w]+_|)C)\\b\\1)",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -1126,7 +1092,7 @@
 			]
 		},
 		{
-			"begin": "(?><<-(\"?)((?:[_\\w]+_|)(?:JS|JAVASCRIPT))\\b\\1)",
+			"begin": "(?><<-('?)((?:[_\\w]+_|)(?:JS|JAVASCRIPT))\\b\\1)",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -1157,7 +1123,7 @@
 			]
 		},
 		{
-			"begin": "(?><<-(\"?)((?:[_\\w]+_|)JQUERY)\\b\\1)",
+			"begin": "(?><<-('?)((?:[_\\w]+_|)JQUERY)\\b\\1)",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -1188,7 +1154,7 @@
 			]
 		},
 		{
-			"begin": "(?><<-(\"?)((?:[_\\w]+_|)(?:SH|SHELL))\\b\\1)",
+			"begin": "(?><<-('?)((?:[_\\w]+_|)(?:SH|SHELL))\\b\\1)",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -1219,7 +1185,7 @@
 			]
 		},
 		{
-			"begin": "(?><<-(\"?)((?:[_\\w]+_|)RUBY)\\b\\1)",
+			"begin": "(?><<-('?)((?:[_\\w]+_|)RUBY)\\b\\1)",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -1250,33 +1216,7 @@
 			]
 		},
 		{
-			"begin": "(?>\\=\\s*<<(\\w+))",
-			"beginCaptures": [
-				{
-					"name": "punctuation.definition.string.begin.crystal"
-				}
-			],
-			"end": "^\\1$",
-			"endCaptures": [
-				{
-					"name": "punctuation.definition.string.end.crystal"
-				}
-			],
-			"name": "string.unquoted.heredoc.crystal",
-			"patterns": [
-				{
-					"include": "#heredoc"
-				},
-				{
-					"include": "#interpolated_crystal"
-				},
-				{
-					"include": "#escaped_char"
-				}
-			]
-		},
-		{
-			"begin": "(?><<-(\\w+))",
+			"begin": "(?><<-('?)(\\w+)\\b\\1)",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"

--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -945,7 +945,7 @@
 			],
 			"comment": "heredoc with embedded HTML and indented terminator",
 			"contentName": "text.html.embedded.crystal",
-			"end": "\\s*\\2$",
+			"end": "\\s*\\2\\b",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -976,7 +976,7 @@
 			],
 			"comment": "heredoc with embedded SQL and indented terminator",
 			"contentName": "text.sql.embedded.crystal",
-			"end": "\\s*\\2$",
+			"end": "\\s*\\2\\b",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -1007,7 +1007,7 @@
 			],
 			"comment": "heredoc with embedded css and intented terminator",
 			"contentName": "text.css.embedded.crystal",
-			"end": "\\s*\\2$",
+			"end": "\\s*\\2\\b",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -1038,7 +1038,7 @@
 			],
 			"comment": "heredoc with embedded c++ and intented terminator",
 			"contentName": "text.c++.embedded.crystal",
-			"end": "\\s*\\2$",
+			"end": "\\s*\\2\\b",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -1069,7 +1069,7 @@
 			],
 			"comment": "heredoc with embedded c++ and intented terminator",
 			"contentName": "text.c.embedded.crystal",
-			"end": "\\s*\\2$",
+			"end": "\\s*\\2\\b",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -1100,7 +1100,7 @@
 			],
 			"comment": "heredoc with embedded javascript and intented terminator",
 			"contentName": "text.js.embedded.crystal",
-			"end": "\\s*\\2$",
+			"end": "\\s*\\2\\b",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -1131,7 +1131,7 @@
 			],
 			"comment": "heredoc with embedded javascript and intented terminator",
 			"contentName": "text.js.jquery.embedded.crystal",
-			"end": "\\s*\\2$",
+			"end": "\\s*\\2\\b",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -1162,7 +1162,7 @@
 			],
 			"comment": "heredoc with embedded shell and intented terminator",
 			"contentName": "text.shell.embedded.crystal",
-			"end": "\\s*\\2$",
+			"end": "\\s*\\2\\b",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -1193,7 +1193,7 @@
 			],
 			"comment": "heredoc with embedded crystal and intented terminator",
 			"contentName": "text.crystal.embedded.crystal",
-			"end": "\\s*\\2$",
+			"end": "\\s*\\2\\b",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -1223,7 +1223,7 @@
 				}
 			],
 			"comment": "heredoc with indented terminator",
-			"end": "\\s*\\1$",
+			"end": "\\s*\\1\\b",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -1247,7 +1247,7 @@
 				}
 			],
 			"comment": "heredoc with indented terminator",
-			"end": "\\s*\\1$",
+			"end": "\\s*\\1\\b",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"

--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -1216,7 +1216,31 @@
 			]
 		},
 		{
-			"begin": "(?><<-('?)(\\w+)\\b\\1)",
+			"begin": "(?><<-'(\\w+)')",
+			"beginCaptures": [
+				{
+					"name": "punctuation.definition.string.begin.crystal"
+				}
+			],
+			"comment": "heredoc with indented terminator",
+			"end": "\\s*\\1$",
+			"endCaptures": [
+				{
+					"name": "punctuation.definition.string.end.crystal"
+				}
+			],
+			"name": "string.unquoted.heredoc.crystal",
+			"patterns": [
+				{
+					"include": "#heredoc"
+				},
+				{
+					"include": "#escaped_char"
+				}
+			]
+		},
+		{
+			"begin": "(?><<-(\\w+)\\b)",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"


### PR DESCRIPTION
This removes the block comment syntax `=begin`/`=end` and `__END__` which are both left over from Ruby but not part of Crystal language.

Also, in Crystal a heredoc without interpolation has the marker wrapped in `'`, not `"`