### PR TITLE
Adds fresh variables to the syntax

### DIFF
--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -205,6 +205,15 @@
 					"name": "punctuation.definition.variable.crystal"
 				}
 			},
+			"match": "(\\%)[a-zA-Z_]\\w*[\\s|\\.\\]",
+			"name": "variable.other.readwrite.fresh.crystal"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.variable.crystal"
+				}
+			},
 			"match": "(\\$)(!|@|&|`|'|\\+|\\d+|~|=|\/|\\\\|,|;|\\.|<|>|_|\\*|\\$|\\?|:|\"|-[0adFiIlpv])",
 			"name": "variable.other.readwrite.global.pre-defined.crystal"
 		},


### PR DESCRIPTION
https://crystal-lang.org/docs/syntax_and_semantics/macros/fresh_variables.html

I don't know much about syntaxes, I just made this change which turned this: 
<img width="765" alt="screen shot 2018-04-27 at 19 36 18" src="https://user-images.githubusercontent.com/6118156/39379282-ad87e6ee-4a52-11e8-90f4-827d0cab5a8a.png">
into this

<img width="775" alt="screen shot 2018-04-27 at 19 36 01" src="https://user-images.githubusercontent.com/6118156/39379299-b45daaa8-4a52-11e8-8201-5602caa22295.png">

I have no idea how to change it to not match on the . though. 
