### PR TITLE
Restricting language services to local files

### DIFF
--- a/src/crystalMain.ts
+++ b/src/crystalMain.ts
@@ -20,13 +20,13 @@ const crystalConfiguration = {
 }
 
 // VSCode identificator for Crystal
-const CRYSTAL_MODE: vscode.DocumentFilter = { language: "crystal", scheme: "file" }
+const CRYSTAL_MODE: client.DocumentSelector = [{ language: "crystal", scheme: "file" }];
 
 /**
  * Ensure to analyze only Crystal documents
  */
 function diagnosticDocument(document) {
-	if (document.languageId == "crystal") {
+	if (document.languageId == "crystal" && document.uri.scheme == "file") {
 		getDiagnostic(document)
 	}
 }
@@ -49,7 +49,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	if (fs.existsSync(scry)) {
 		let serverOptions = { command: scry, args: [] }
 		let clientOptions: client.LanguageClientOptions = {
-			documentSelector: ["crystal"],
+			documentSelector: CRYSTAL_MODE,
 			synchronize: {
 				configurationSection: "crystal-lang",
 				fileEvents: vscode.workspace.createFileSystemWatcher("**/*.cr")
@@ -61,11 +61,11 @@ export async function activate(context: vscode.ExtensionContext) {
 		// If server is disabled use Node.js implementation instead.
 		context.subscriptions.push(
 			diagnosticCollection,
-			vscode.languages.registerDocumentFormattingEditProvider("crystal", new CrystalFormattingProvider()),
+			vscode.languages.registerDocumentFormattingEditProvider(CRYSTAL_MODE, new CrystalFormattingProvider()),
 			vscode.workspace.onDidOpenTextDocument(diagnosticDocument),
 			vscode.workspace.onDidSaveTextDocument(diagnosticDocument),
 			vscode.languages.registerHoverProvider(CRYSTAL_MODE, new CrystalHoverProvider()),
-			vscode.languages.registerDocumentSymbolProvider("crystal", new CrystalDocumentSymbolProvider()),
+			vscode.languages.registerDocumentSymbolProvider(CRYSTAL_MODE, new CrystalDocumentSymbolProvider()),
 			vscode.languages.registerCompletionItemProvider(CRYSTAL_MODE, new CrystalCompletionItemProvider())
 		)
 		if (config["implementations"]) {


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for Crystal, this PR simply updates the current `DocumentSelector` to be limited to local files. This way, when someone has the Crystal extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

If someone joins a Crystal project using Live Share, and doesn't have the Crystal extension installed, then they will automatically receive language services from the host (which is awesome! 🎉), so this PR is simply an optimization for the case where collaborating developers both have the Crystal extension installed. Additionally, this wouldn't impact the "local" Crystal development experience.