### PR TITLE
Corrected regex issue and covered dotted fresh variables

### DIFF
--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -205,7 +205,7 @@
 					"name": "punctuation.definition.variable.crystal"
 				}
 			},
-			"match": "(\\%)[a-zA-Z_]\\w*[\\s|\\.\\]",
+			"match": "(\\%)([a-zA-Z_]\\w*\\.)*[a-zA-Z_]\\w*",
 			"name": "variable.other.readwrite.fresh.crystal"
 		},
 		{


### PR DESCRIPTION
This repairs an error that broke Crystal syntax highlighting and also improves fresh variable highlighting:

<img width="1392" alt="screen shot 2018-06-14 at 7 21 05 pm" src="https://user-images.githubusercontent.com/1811813/41403397-1c1b4d50-7008-11e8-8cbb-bc195bbe2a68.png">

Cheers
Fotis