### PR TITLE
Fix completion trigger and syntax highlight

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"languages"
 	],
 	"categories": [
-		"Languages"
+    "Programming Languages"
 	],
 	"galleryBanner": {
 		"color": "#000000",

--- a/src/crystalMain.ts
+++ b/src/crystalMain.ts
@@ -66,7 +66,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			vscode.workspace.onDidSaveTextDocument(diagnosticDocument),
 			vscode.languages.registerHoverProvider(CRYSTAL_MODE, new CrystalHoverProvider()),
 			vscode.languages.registerDocumentSymbolProvider(CRYSTAL_MODE, new CrystalDocumentSymbolProvider()),
-			vscode.languages.registerCompletionItemProvider(CRYSTAL_MODE, new CrystalCompletionItemProvider())
+			vscode.languages.registerCompletionItemProvider(CRYSTAL_MODE, new CrystalCompletionItemProvider(), '.')
 		)
 		if (config["implementations"]) {
 			context.subscriptions.push(

--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -111,7 +111,7 @@
 		},
 		{
 			"comment": "everything being a reserved word, not a value and needing a 'end' is a..",
-			"match": "(?<!\\.)\\b(alias|as|begin|case|abstract|class|ensure|for|fun|if|in|lib|module|of|out|previous_def|private|protected|rescue|struct|with|union|enum|macro|then|type|unless|until|while|select)\\b(?![?!])",
+			"match": "(?<!\\.)\\b(alias|as|begin|case|abstract|class|ensure|for|fun|if|in|lib|module|of|previous_def|private|protected|rescue|struct|with|union|enum|macro|then|type|unless|until|while|select)\\b(?![?!])",
 			"name": "keyword.control.primary.crystal"
 		},
 		{
@@ -198,15 +198,6 @@
 			},
 			"match": "(\\$)[a-zA-Z_]\\w*",
 			"name": "variable.other.readwrite.global.crystal"
-		},
-		{
-			"captures": {
-				"1": {
-					"name": "punctuation.definition.variable.crystal"
-				}
-			},
-			"match": "(\\%)[a-zA-Z_]\\w*[\\s|\\.\\]",
-			"name": "variable.other.readwrite.fresh.crystal"
 		},
 		{
 			"captures": {


### PR DESCRIPTION
1. master crystal syntax file can't highlight, back to 0.1.0 it will be ok, I don't the syntax file's want do what, but it should be worked
2.vscode CompletionItemProvider should provide a trigger array of strings, I simply use the '.'. when I typed '.' follow by a variable it can remind me. 0.1.0 can't.
![image](https://user-images.githubusercontent.com/10645383/48567911-323bfd00-e939-11e8-9c3e-3efa4f4f3d86.png)

3. 'categories' in package.json may be 'Programming Languages' not 'Languages'.  Vascode told me that.


thanks so much, I love crystal, but a newbie, good tools maybe attract more people.