### PR TITLE
Fix bug of hover tooltip

### DIFF
--- a/src/crystalHover.ts
+++ b/src/crystalHover.ts
@@ -72,15 +72,13 @@ export class CrystalHoverProvider extends CrystalContext implements vscode.Hover
 				if (isNotKeyword(word) && !parseInt(word) && !stop) {
 					// Checks Symbols
 					let symbols = await getSymbols(document.uri)
-					if (symbols !== undefined) {
-						for (let symbol of symbols) {
-							if (symbol.name == word) {
-								let container = symbol.containerName ? ` of ${symbol.containerName}` : ""
-								return new vscode.Hover({
-									language: "plaintext",
-									value: `${vscode.SymbolKind[symbol.kind]} ${symbol.name}${container}`
-								})
-							}
+					for (let symbol of symbols) {
+						if (symbol.name == word) {
+							let container = symbol.containerName ? ` of ${symbol.containerName}` : ""
+							return new vscode.Hover({
+								language: "plaintext",
+								value: `${vscode.SymbolKind[symbol.kind]} ${symbol.name}${container}`
+							})
 						}
 					}
 					// Checks completion data

--- a/src/crystalHover.ts
+++ b/src/crystalHover.ts
@@ -72,13 +72,15 @@ export class CrystalHoverProvider extends CrystalContext implements vscode.Hover
 				if (isNotKeyword(word) && !parseInt(word) && !stop) {
 					// Checks Symbols
 					let symbols = await getSymbols(document.uri)
-					for (let symbol of symbols) {
-						if (symbol.name == word) {
-							let container = symbol.containerName ? ` of ${symbol.containerName}` : ""
-							return new vscode.Hover({
-								language: "plaintext",
-								value: `${vscode.SymbolKind[symbol.kind]} ${symbol.name}${container}`
-							})
+					if (symbols !== undefined) {
+						for (let symbol of symbols) {
+							if (symbol.name == word) {
+								let container = symbol.containerName ? ` of ${symbol.containerName}` : ""
+								return new vscode.Hover({
+									language: "plaintext",
+									value: `${vscode.SymbolKind[symbol.kind]} ${symbol.name}${container}`
+								})
+							}
 						}
 					}
 					// Checks completion data

--- a/src/crystalUtils.ts
+++ b/src/crystalUtils.ts
@@ -143,7 +143,8 @@ export function isNotLib(file) {
  * Seach symbols for a crystal document
  */
 export function getSymbols(uri): Thenable<vscode.SymbolInformation[]> {
-	return vscode.commands.executeCommand("vscode.executeDocumentSymbolProvider", uri)
+	return vscode.commands.executeCommand<vscode.SymbolInformation[]>("vscode.executeDocumentSymbolProvider", uri)
+		.then(symbols => symbols === undefined ? [] : symbols)
 }
 
 /**


### PR DESCRIPTION
The command "executeDocumentSymbolProvider" returns undefined when symbols aren't found in a document.