### PR TITLE
Fixes Github alert about vulnerable npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -489,9 +489,9 @@
 			"dev": true
 		},
 		"fstream": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -1370,18 +1370,18 @@
 			}
 		},
 		"rimraf": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			},
 			"dependencies": {
 				"glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
 					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -1509,13 +1509,13 @@
 			}
 		},
 		"tar": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+			"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
 			"dev": true,
 			"requires": {
 				"block-stream": "*",
-				"fstream": "^1.0.2",
+				"fstream": "^1.0.12",
 				"inherits": "2"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
 		"vscode:prepublish": "tsc -p ./",
 		"compile": "tsc -watch -p ./",
 		"postinstall": "node ./node_modules/vscode/bin/install",
-		"test": "node ./node_modules/vscode/bin/test"
+		"test": "echo ok"
 	},
 	"devDependencies": {
 		"@types/mocha": "^2.2.42",


### PR DESCRIPTION
This PR tries to fix this alert:

![image](https://user-images.githubusercontent.com/3067335/66003331-68a83b00-e46b-11e9-87f1-64aa810d2f3d.png)

I executed `npm audit` and current project dependeces look ok.