### PR TITLE
Fixed problems with formatting the code with errors #84

### DIFF
--- a/src/crystalUtils.ts
+++ b/src/crystalUtils.ts
@@ -199,7 +199,7 @@ export function searchProblemsFromRaw(response: string, uri: vscode.Uri) {
 
 	const config = vscode.workspace.getConfiguration("crystal-lang")
 
-	let responseData = response.match(/.* in .*(\d+): (.*)/)
+	let responseData = response.match(/.* in .*?(\d+):\S* (.*)/)
 
 	let parsedLine:number
 


### PR DESCRIPTION
Only changing of the regular expression is enough to fix the bug #84.

Though, separation of the data from stdout and stderr helps to avoid potential issues with "malicious" strings in the source (for example, inclusion of the string "Syntax error in test.cr:5:1: ooops" in the source will create phantom error on line 5 after the formatting). 