### PR TITLE
Explicitly set UTF-8 encoding when formatting

### DIFF
--- a/src/crystalFormatting.ts
+++ b/src/crystalFormatting.ts
@@ -20,6 +20,7 @@ export class CrystalFormattingProvider implements vscode.DocumentFormattingEditP
 			let child = spawn(`${config["compiler"]}`, ["tool", "format", "--no-color", "-"])
 			child.stdin.write(document.getText())
 			child.stdin.end()
+			child.stdout.setEncoding('utf-8')
 			childOnError(child)
 			child.stdout.on("data", (data) => {
 				responseOut += data


### PR DESCRIPTION
For https://github.com/crystal-lang-tools/vscode-crystal-lang/issues/114

STDOUT streamed data is being returned as a Buffer object because encoding property was never set (it's `null` by default: https://nodejs.org/api/stream.html#stream_readable_setencoding_encoding).
Explicitly setting stdout's stream encoding to UTF-8 helps parse formatter's output correctly.