### PR TITLE
Correctly highlight `%Q(...)` and others

### DIFF
--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -224,7 +224,7 @@
 					"name": "punctuation.definition.variable.crystal"
 				}
 			},
-			"match": "(\\%)([a-zA-Z_]\\w*\\.)*[a-zA-Z_]\\w*",
+			"match": "(?!%[QWSR][\\(\\[\\{\\<\\|])(\\%)([a-zA-Z_]\\w*\\.)*[a-zA-Z_]\\w*",
 			"name": "variable.other.readwrite.fresh.crystal"
 		},
 		{


### PR DESCRIPTION
The syntax highlighting for `%Q(...)` conflicts with that of free
variables inside macros, such as `%hello`. It conflicts because `%Q...`
is taken to be a free variable, when it shouldn't. So, this PR excludes
some specific patterns for the "free variables" syntax matching.

Fixes #128