### PR TITLE
Fix syntax highlighting for the 0 literal

### DIFF
--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -347,7 +347,7 @@
 		{
 			"comment": "Integer literal (decimal)",
 			"name": "constant.numeric.integer.decimal.crystal",
-			"match": "\\b([1-9]|[0-9]_)[0-9_]*([ui](8|16|32|64|128))?\\b"
+			"match": "\\b(?!0[0-9])[0-9][0-9_]*([ui](8|16|32|64|128))?\\b"
 		},
 		{
 			"comment": "Integer literal (hexadecimal)",


### PR DESCRIPTION
The sole `0` isn't currently highlighted because the regex assumes it must then be followed by an underscore to be recognized as a deicmal integer literal.