### PR TITLE
Update Crystal syntax highlighting

### DIFF
--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -1,17 +1,15 @@
 {
 	"information_for_contributors": [
-		"This file has been converted from https://github.com/Microsoft/vscode/blob/master/extensions/ruby/syntaxes/ruby.tmLanguage.json",
-		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
-		"Once accepted there, we are happy to receive an update request."
+		"This file is based on https://github.com/Microsoft/vscode/blob/master/extensions/ruby/syntaxes/ruby.tmLanguage.json"
 	],
-	"version": "https://github.com/Microsoft/vscode/blob/8fdf170a0850c1cc027382f31650aaf300d3ae2a/extensions/ruby/syntaxes/ruby.tmLanguage.json",
+	"version": "https://github.com/Microsoft/vscode/blob/3f1f36333d3453f67a36b6bfb1206e9159e9c4f0/extensions/ruby/syntaxes/ruby.tmLanguage.json",
 	"name": "Crystal",
 	"scopeName": "source.crystal",
 	"fileTypes": [
 		"cr"
 	],
 	"firstLineMatch": "^#!\/.*\\bcrystal",
-	"foldingStartMarker": "(?x)^(\\s*+(annotation|module|class|def(?!.*\\bend\\s*$)|unless|if|case|begin|for|while|until|record|^=begin|(\"(\\\\.|[^\"])*+\"|'(\\\\.|[^'])*+'|[^#\"'])*(\\s(do|begin|case)|(?<!\\$)[-+=&|*\/~%^<>~]\\s*+(if|unless)))\\b(?![^;]*+;.*?\\bend\\b)|(\"(\\\\.|[^\"])*+\"|'(\\\\.|[^'])*+'|[^#\"'])*(\\{(?![^}]*+\\})|\\[(?![^\\]]*+\\]))).*$|[#].*?\\(fold\\)\\s*+$",
+	"foldingStartMarker": "(?x)^(\\s*+(annotation|module|class|struct|union|enum|def(?!.*\\bend\\s*$)|unless|if|case|begin|for|while|until|^=begin|(\"(\\\\.|[^\"])*+\"|'(\\\\.|[^'])*+'|[^#\"'])*(\\s(do|begin|case)|(?<!\\$)[-+=&|*\/~%^<>~]\\s*+(if|unless)))\\b(?![^;]*+;.*?\\bend\\b)|(\"(\\\\.|[^\"])*+\"|'(\\\\.|[^'])*+'|[^#\"'])*(\\{(?![^}]*+\\})|\\[(?![^\\]]*+\\]))).*$|[#].*?\\(fold\\)\\s*+$",
 	"foldingStopMarker": "(?x)((^|;)\\s*+end\\s*+([#].*)?$|(^|;)\\s*+end\\..*$|^\\s*+[}\\]] ,?\\s*+([#].*)?$|[#].*?\\(end\\)\\s*+$|^=end)",
 	"keyEquivalent": "^~R",
 	"patterns": [
@@ -48,7 +46,7 @@
 					"name": "punctuation.definition.variable.crystal"
 				}
 			},
-			"match": "(?x)^\\s*(abstract)?\\s*(class|struct|union|annotation)\\s+(([.A-Z_:\\x{80}-\\x{10FFFF}][.\\w:\\x{80}-\\x{10FFFF}]*(\\(([,\\s.a-zA-Z0-9_:\\x{80}-\\x{10FFFF}]+)\\))?(\\s*(<)\\s*[.:A-Z\\x{80}-\\x{10FFFF}][.:\\w\\x{80}-\\x{10FFFF}]*(\\(([.a-zA-Z0-9_:]+\\s,)\\))?)?)|((<<)\\s*[.A-Z0-9_:\\x{80}-\\x{10FFFF}]+))",
+			"match": "(?x)^\\s*(abstract)?\\s*(class|struct|union|annotation|enum)\\s+(([.A-Z_:\\x{80}-\\x{10FFFF}][.\\w:\\x{80}-\\x{10FFFF}]*(\\(([,\\s.a-zA-Z0-9_:\\x{80}-\\x{10FFFF}]+)\\))?(\\s*(<)\\s*[.:A-Z\\x{80}-\\x{10FFFF}][.:\\w\\x{80}-\\x{10FFFF}]*(\\(([.a-zA-Z0-9_:]+\\s,)\\))?)?)|((<<)\\s*[.A-Z0-9_:\\x{80}-\\x{10FFFF}]+))",
 			"name": "meta.class.crystal"
 		},
 		{
@@ -132,12 +130,12 @@
 		},
 		{
 			"comment": "everything being a reserved word, not a value and needing a 'end' is a..",
-			"match": "(?<!\\.)\\b(fun|begin|case|class|else|elsif|end|ensure|for|if|in|module|rescue|then|unless|until|when|while)\\b(?![?!])",
+			"match": "(?<!\\.)\\b(fun|begin|case|class|else|elsif|end|ensure|enum|for|if|macro|module|rescue|struct|then|union|unless|until|when|while)\\b(?![?!:])",
 			"name": "keyword.control.crystal"
 		},
 		{
-			"comment": "everything being a reserved word, not a value and needing a 'end' is a..",
-			"match": "(?<!\\.)\\b(as|abstract|ensure|fun|in|lib|of|out|previous_def|private|protected|struct|with|union|enum|macro|select|record)\\b(?![?!])",
+			"comment": "everything being a reserved word, not a value and not needing a 'end' is a..",
+			"match": "(?<!\\.)\\b(abstract|alias|asm|break|extend|in|include|next|of|private|protected|struct|return|select|super|with|yield)\\b(?![?!:])",
 			"name": "keyword.control.primary.crystal"
 		},
 		{
@@ -152,29 +150,29 @@
 		},
 		{
 			"comment": "Just as above but being not a logical operation",
-			"match": "(?<!\\.)\\b(asm|alias|alias_method|break|next|pointerof|typeof|sizeof|instance_sizeof|offsetof|return|super|yield|uninitialized)\\b(?![?!])",
+			"match": "(?<!\\.)\\b(pointerof|typeof|sizeof|instance_sizeof|offsetof|previous_def|forall|out|uninitialized)\\b(?![?!:])|\\.(is_a\\?|nil\\?|responds_to\\?|as\\?|as\b)",
 			"name": "keyword.control.pseudo-method.crystal"
 		},
 		{
-			"match": "\\bnil\\b(?![?!])",
+			"match": "\\bnil\\b(?![?!:])",
 			"name": "constant.language.nil.crystal"
 		},
 		{
-			"match": "\\b(true|false)\\b(?![?!])",
+			"match": "\\b(true|false)\\b(?![?!:])",
 			"name": "constant.language.boolean.crystal"
 		},
 		{
-			"match": "\\b(__(FILE|LINE|DIR)__)\\b(?![?!])",
+			"match": "\\b(__(DIR|FILE|LINE|END_LINE)__)\\b(?![?!:])",
 			"name": "variable.language.crystal"
 		},
 		{
-			"match": "\\bself\\b(?![?!])",
+			"match": "\\b(self)\\b(?![?!:])",
 			"name": "variable.language.self.crystal"
 		},
 		{
-			"comment": "Everything being a method but having a special function is a..",
-			"match": "\\b(initialize|new|loop|include|extend|raise|getter|setter|property|class_getter|class_setter|class_property|describe|it|with|delegate|def_hash|def_equals|def_equals_and_hash|forward_missing_to|assert_responds_to|spawn|finalize)\\b[!?]?",
-			"name": "keyword.other.special-method.crystal"
+			"comment": "https://crystal-lang.org/api/0.36.1/Object.html#macro-summary",
+			"match": "(?<!\\.)\\b(((class_)?((getter|property)\\b[!?]?|setter\\b))|(def_(clone|equals|equals_and_hash|hash)|delegate|forward_missing_to)\\b)(?![?!:])",
+			"name": "support.function.kernel.crystal"
 		},
 		{
 			"begin": "\\b(require)\\b",
@@ -224,7 +222,7 @@
 					"name": "punctuation.definition.variable.crystal"
 				}
 			},
-			"match": "(?!%[QWSR][\\(\\[\\{\\<\\|])(\\%)([a-zA-Z_]\\w*\\.)*[a-zA-Z_]\\w*",
+			"match": "(?!%[Qxrqwi]?[\\(\\[\\{\\<\\|])%([a-zA-Z_]\\w*\\.)*[a-zA-Z_]\\w*",
 			"name": "variable.other.readwrite.fresh.crystal"
 		},
 		{
@@ -252,19 +250,19 @@
 			]
 		},
 		{
+			"match": "\\b[A-Z\\x{80}-\\x{10FFFF}][\\w\\x{80}-\\x{10FFFF}]*",
+			"name": "support.class.crystal",
+			"comment": "Literals name of Crystal"
+		},
+		{
+			"match": "(?<!\\.)\\b(abort|at_exit|caller|exit|gets|loop|main|p|pp|print|printf|puts|raise|rand|read_line|sleep|spawn|sprintf|system|debugger|record|spawn)\\b(?![?!:])",
+			"name": "support.function.kernel.crystal",
+			"comment": "Fetch from https://crystal-lang.org/api/0.36.1/toplevel.html"
+		},
+		{
 			"match": "\\b[_A-Z]+\\b",
 			"name": "variable.other.constant.crystal",
 			"comment": "Constant name in any where"
-		},
-		{
-			"match": "\\b[A-Z\\x{80}-\\x{10FFFF}][\\w\\x{80}-\\x{10FFFF}]*",
-			"name": "support.class.crystal",
-			"commenct": "Literals name of Crystal"
-		},
-		{
-			"match": "\\b(abort|at_exit|caller|delay|exit|fork|future|lazy|loop|main|p|pp|print|printf|puts|rand|read_line|sleep|spawn|sprintf|system|with_color|debugger)\\b[!?]?",
-			"name": "support.function.kernel.crystal",
-			"comment": "Fetch from https://crystal-lang.org/api/0.27.0/toplevel.html"
 		},
 		{
 			"begin": "(?x)\n(?=def\\b)                          # optimization to help Oniguruma fail fast\n(?<=^|\\s)(def)\\s+\n(\n  (?>[a-zA-Z_]\\w*(?>\\.|::))?      # method prefix\n  (?>                               # method name\n    [a-zA-Z_]\\w*(?>[?!]|=(?!>))?\n    |\n    \\^|===?|!=|>[>=]?|<=>|<[<=]?|[%&`/\\|]|\\*\\*?|=?~|[-+]@?|\\[][?=]?|\\[]=?\n  )\n)\n\\s*(\\()",
@@ -298,7 +296,7 @@
 									"name": "storage.type.variable.crystal"
 								},
 								"2": {
-									"name": "constant.language.symbol.hashkey.parameter.function.crystal"
+									"name": "constant.other.symbol.hashkey.parameter.function.crystal"
 								},
 								"3": {
 									"name": "punctuation.definition.constant.hashkey.crystal"
@@ -356,7 +354,7 @@
 		},
 		{
 			"comment": "Integer literal (octal)",
-			"name": "constant.numeric.integer.octal.rust",
+			"name": "constant.numeric.integer.octal.crystal",
 			"match": "\\b0o[0-7_]+([ui](8|16|32|64|128))?\\b"
 		},
 		{
@@ -378,7 +376,7 @@
 					"name": "punctuation.definition.symbol.end.crystal"
 				}
 			},
-			"name": "constant.language.symbol.crystal",
+			"name": "constant.other.symbol.crystal",
 			"patterns": [
 				{
 					"match": "\\\\['\\\\]",
@@ -400,7 +398,7 @@
 					"name": "punctuation.section.symbol.end.crystal"
 				}
 			},
-			"name": "constant.language.symbol.interpolated.crystal",
+			"name": "constant.other.symbol.interpolated.crystal",
 			"patterns": [
 				{
 					"include": "#interpolated_crystal"
@@ -594,14 +592,14 @@
 			]
 		},
 		{
-			"begin": "%x([^\\w])",
+			"begin": "%x\\|",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
 				}
 			],
 			"comment": "execute string (allow for interpolation)",
-			"end": "\\1",
+			"end": "\\|",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -629,7 +627,7 @@
 			},
 			"comment": "regular expressions (normal) we only start a regexp if the character before it (excluding whitespace) is what we think is before a regexp",
 			"contentName": "string.regexp.classic.crystal",
-			"end": "((\/[eimnosux]*))",
+			"end": "((\/[imsx]*))",
 			"patterns": [
 				{
 					"include": "#regex_sub"
@@ -644,7 +642,7 @@
 				}
 			],
 			"comment": "regular expressions (literal)",
-			"end": "\\}[eimnosux]*",
+			"end": "\\}[imsx]*",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -668,7 +666,7 @@
 				}
 			],
 			"comment": "regular expressions (literal)",
-			"end": "\\][eimnosux]*",
+			"end": "\\][imsx]*",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -692,7 +690,7 @@
 				}
 			],
 			"comment": "regular expressions (literal)",
-			"end": "\\)[eimnosux]*",
+			"end": "\\)[imsx]*",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -716,7 +714,7 @@
 				}
 			],
 			"comment": "regular expressions (literal)",
-			"end": "\\>[eimnosux]*",
+			"end": "\\>[imsx]*",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -733,14 +731,14 @@
 			]
 		},
 		{
-			"begin": "%r([^\\w])",
+			"begin": "%r\\|",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
 				}
 			],
 			"comment": "regular expressions (literal)",
-			"end": "\\1[eimnosux]*",
+			"end": "\\|[imsx]*",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -754,7 +752,7 @@
 			]
 		},
 		{
-			"begin": "%[QWSR]?\\(",
+			"begin": "%Q?\\(",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -781,7 +779,7 @@
 			]
 		},
 		{
-			"begin": "%[QWSR]?\\[",
+			"begin": "%Q?\\[",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -808,7 +806,7 @@
 			]
 		},
 		{
-			"begin": "%[QWSR]?\\<",
+			"begin": "%Q?\\<",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -835,7 +833,7 @@
 			]
 		},
 		{
-			"begin": "%[QWSR]?\\{",
+			"begin": "%Q?\\{",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -862,14 +860,14 @@
 			]
 		},
 		{
-			"begin": "%[QWSR]([^\\w])",
+			"begin": "%Q\\|",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
 				}
 			],
-			"comment": "literal capable of interpolation -- wildcard",
-			"end": "\\1",
+			"comment": "literal capable of interpolation -- ||",
+			"end": "\\|",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -886,7 +884,7 @@
 			]
 		},
 		{
-			"begin": "%[qws]\\(",
+			"begin": "%[qwi]\\(",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -911,7 +909,7 @@
 			]
 		},
 		{
-			"begin": "%[qws]\\<",
+			"begin": "%[qwi]\\<",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -936,7 +934,7 @@
 			]
 		},
 		{
-			"begin": "%[qws]\\[",
+			"begin": "%[qwi]\\[",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -961,7 +959,7 @@
 			]
 		},
 		{
-			"begin": "%[qws]\\{",
+			"begin": "%[qwi]\\{",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
@@ -986,14 +984,14 @@
 			]
 		},
 		{
-			"begin": "%[qws]([^\\w])",
+			"begin": "%[qwi]\\|",
 			"beginCaptures": [
 				{
 					"name": "punctuation.definition.string.begin.crystal"
 				}
 			],
-			"comment": "literal incapable of interpolation -- wildcard",
-			"end": "\\1",
+			"comment": "literal incapable of interpolation -- ||",
+			"end": "\\|",
 			"endCaptures": [
 				{
 					"name": "punctuation.definition.string.end.crystal"
@@ -1014,7 +1012,7 @@
 				}
 			},
 			"comment": "symbols",
-			"match": "(?<!:)(:)(?>[a-zA-Z_\\x{80}-\\x{10FFFF}][\\w\\x{80}-\\x{10FFFF}]*(?>[?!]|=(?![>=]))?|===?|>[>=]?|<[<=]?|<=>|[%&`\/\\|]|\\*\\*?|=?~|[-+]@?|\\[\\]=?|@@?[a-zA-Z_\\x{80}-\\x{10FFFF}][\\w\\x{80}-\\x{10FFFF}]*)",
+			"match": "(?<!:)(:)(?>[a-zA-Z_\\x{80}-\\x{10FFFF}][\\w\\x{80}-\\x{10FFFF}]*(?>[?!]|=(?![>=]))?|===?|>[>=]?|<[<=]?|<=>|[%&`\/\\|]|\\*\\*?|=?~|[-+]@?|\\[\\][?=]?|@@?[a-zA-Z_\\x{80}-\\x{10FFFF}][\\w\\x{80}-\\x{10FFFF}]*)",
 			"name": "constant.other.symbol.crystal"
 		},
 		{
@@ -1405,10 +1403,6 @@
 			"name": "keyword.operator.comparison.crystal"
 		},
 		{
-			"match": "(?<!\\.)\\b(and|not|or)\\b(?![?!])",
-			"name": "keyword.operator.logical.crystal"
-		},
-		{
 			"match": "(?<=^|[ \\t])!|&&|\\|\\||\\^",
 			"name": "keyword.operator.logical.crystal"
 		},
@@ -1493,7 +1487,8 @@
 	],
 	"repository": {
 		"escaped_char": {
-			"match": "\\\\(?:[0-7]{1,3}|x[\\da-fA-F]{1,2}|.)",
+			"comment": "https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html",
+			"match": "\\\\(?:[\\\\abefnrtv#\"\\']|[0-7]{1,3}|x[a-fA-F0-9]{2}|u[a-fA-F0-9]{4}|u\\{[a-fA-F0-9 ]+\\})",
 			"name": "constant.character.escape.crystal"
 		},
 		"heredoc": {


### PR DESCRIPTION
(In the order of the diff:)

* Add missing "rare" keywords for opening a type, such as `enum`.
* Remove non-keywords: `initialize`, `it`, `alias_method`, `and` and others.
* Add missing keywords such as `forall`.
* Don't highlight keywords right before a colon, these always become named args. Fixes #133.
* Highlight `.is_a?` and other pseudo-methods as keywords.
* Update the list of builtins, for example, remove `delay`, add `gets`.
* Don't highlight builtins if they immediately follow a dot.
* Don't highlight builtins such as `class_property` as keywords, rather just normal builtins.
* Remove Ruby's %W %S %R %s strings, add %i strings.
* Remove Ruby's arbitrary delimiter strings `%OstringO`, keep only `%|string|`.
* Highlight quoted symbols `:"sym"` same as normal symbols.
* Update the list of regex flags.
* Highlight `:[]=` symbol just like `:[]?`.
* Precisely define what kind of escape sequences in a string are valid.

![Peek 2021-03-07 17-38](https://user-images.githubusercontent.com/371383/110247342-14f92580-7f6c-11eb-9fea-47467b98f13c.gif)
