### PR TITLE
Fix some typos

### DIFF
--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -369,7 +369,7 @@
 					"name": "punctuation.definition.symbol.begin.crystal"
 				}
 			},
-			"comment": "symbol literal with '' delimitor",
+			"comment": "symbol literal with '' delimiter",
 			"end": "'",
 			"endCaptures": {
 				"0": {
@@ -391,7 +391,7 @@
 					"name": "punctuation.section.symbol.begin.crystal"
 				}
 			},
-			"comment": "symbol literal with \"\" delimitor",
+			"comment": "symbol literal with \"\" delimiter",
 			"end": "\"",
 			"endCaptures": {
 				"0": {
@@ -420,7 +420,7 @@
 					"name": "punctuation.definition.string.begin.crystal"
 				}
 			},
-			"comment": "string literal with '' delimitor",
+			"comment": "string literal with '' delimiter",
 			"end": "'",
 			"endCaptures": {
 				"0": {
@@ -442,7 +442,7 @@
 					"name": "punctuation.definition.string.begin.crystal"
 				}
 			},
-			"comment": "string literal with interpolation and \"\" delimitor",
+			"comment": "string literal with interpolation and \"\" delimiter",
 			"end": "\"",
 			"endCaptures": {
 				"0": {

--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -1000,7 +1000,7 @@
 			"name": "string.quoted.other.literal.lower.crystal",
 			"patterns": [
 				{
-					"comment": "Cant be named because its not neccesarily an escape.",
+					"comment": "Cant be named because its not necessarily an escape.",
 					"match": "\\\\."
 				}
 			]

--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -409,7 +409,7 @@
 			]
 		},
 		{
-			"comment": "Needs higher precidence than regular expressions.",
+			"comment": "Needs higher precedence than regular expressions.",
 			"match": "(?<!\\()/=",
 			"name": "keyword.operator.assignment.augmented.crystal"
 		},


### PR DESCRIPTION
I found these typos in following repository 😅 

* https://github.com/rubyide/vscode-ruby/pull/709
* https://github.com/microsoft/vscode/pull/118923
* https://github.com/textmate/ruby.tmbundle/pull/138
* https://github.com/atom/language-ruby/pull/294