### PR TITLE
Syntaxes: fix regex escapes

### DIFF
--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -1488,7 +1488,7 @@
 	"repository": {
 		"escaped_char": {
 			"comment": "https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html",
-			"match": "\\\\(?:[\\\\abefnrtv#\"\\']|[0-7]{1,3}|x[a-fA-F0-9]{2}|u[a-fA-F0-9]{4}|u\\{[a-fA-F0-9 ]+\\})",
+			"match": "\\\\(?:[0-7]{1,3}|x[a-fA-F0-9]{2}|u[a-fA-F0-9]{4}|u\\{[a-fA-F0-9 ]+\\}|.)",
 			"name": "constant.character.escape.crystal"
 		},
 		"heredoc": {


### PR DESCRIPTION
Regex metacharacters escapes (like `\.`, `\*`, `\[`, ...) not work, e.g. `\/` breaks syntax highlight. Changed it to match any single char escape. 
Based on [vscode-ruby](https://github.com/rubyide/vscode-ruby/blob/main/packages/vscode-ruby/syntaxes/ruby.cson.json#L2376).

Before:
![Screenshot_20210719_112522](https://user-images.githubusercontent.com/1209067/126183020-78e3c2f7-29a2-4257-960d-203e8d681c2e.png)

After:
![Screenshot_20210719_112720](https://user-images.githubusercontent.com/1209067/126183039-fd47f56d-b0d2-4a7f-b54c-a9bcba51335c.png)
