### PR TITLE
make Crystal grammar compatible with TextMate

### DIFF
--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -485,18 +485,18 @@
 		},
 		{
 			"begin": "%x\\{",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "execute string (allow for interpolation)",
 			"end": "\\}",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.interpolated.crystal",
 			"patterns": [
 				{
@@ -512,18 +512,18 @@
 		},
 		{
 			"begin": "%x\\[",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				 "0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "execute string (allow for interpolation)",
 			"end": "\\]",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.interpolated.crystal",
 			"patterns": [
 				{
@@ -539,18 +539,18 @@
 		},
 		{
 			"begin": "%x\\<",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "execute string (allow for interpolation)",
 			"end": "\\>",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.interpolated.crystal",
 			"patterns": [
 				{
@@ -566,18 +566,18 @@
 		},
 		{
 			"begin": "%x\\(",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "execute string (allow for interpolation)",
 			"end": "\\)",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.interpolated.crystal",
 			"patterns": [
 				{
@@ -593,18 +593,18 @@
 		},
 		{
 			"begin": "%x\\|",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "execute string (allow for interpolation)",
 			"end": "\\|",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.interpolated.crystal",
 			"patterns": [
 				{
@@ -636,18 +636,18 @@
 		},
 		{
 			"begin": "%r\\{",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "regular expressions (literal)",
 			"end": "\\}[imsx]*",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.regexp.mod-r.crystal",
 			"patterns": [
 				{
@@ -660,18 +660,18 @@
 		},
 		{
 			"begin": "%r\\[",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "regular expressions (literal)",
 			"end": "\\][imsx]*",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.regexp.mod-r.crystal",
 			"patterns": [
 				{
@@ -684,18 +684,18 @@
 		},
 		{
 			"begin": "%r\\(",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "regular expressions (literal)",
 			"end": "\\)[imsx]*",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.regexp.mod-r.crystal",
 			"patterns": [
 				{
@@ -708,18 +708,18 @@
 		},
 		{
 			"begin": "%r\\<",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "regular expressions (literal)",
 			"end": "\\>[imsx]*",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.regexp.mod-r.crystal",
 			"patterns": [
 				{
@@ -732,18 +732,18 @@
 		},
 		{
 			"begin": "%r\\|",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "regular expressions (literal)",
 			"end": "\\|[imsx]*",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.regexp.mod-r.crystal",
 			"patterns": [
 				{
@@ -753,18 +753,18 @@
 		},
 		{
 			"begin": "%Q?\\(",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "literal capable of interpolation ()",
 			"end": "\\)",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.quoted.other.literal.upper.crystal",
 			"patterns": [
 				{
@@ -780,18 +780,18 @@
 		},
 		{
 			"begin": "%Q?\\[",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "literal capable of interpolation []",
 			"end": "\\]",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.quoted.other.literal.upper.crystal",
 			"patterns": [
 				{
@@ -807,18 +807,18 @@
 		},
 		{
 			"begin": "%Q?\\<",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "literal capable of interpolation <>",
 			"end": "\\>",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.quoted.other.literal.upper.crystal",
 			"patterns": [
 				{
@@ -834,18 +834,18 @@
 		},
 		{
 			"begin": "%Q?\\{",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "literal capable of interpolation -- {}",
 			"end": "\\}",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.quoted.double.crystal.mod",
 			"patterns": [
 				{
@@ -861,18 +861,18 @@
 		},
 		{
 			"begin": "%Q\\|",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "literal capable of interpolation -- ||",
 			"end": "\\|",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.quoted.other.literal.upper.crystal",
 			"patterns": [
 				{
@@ -885,18 +885,18 @@
 		},
 		{
 			"begin": "%[qwi]\\(",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "literal incapable of interpolation -- ()",
 			"end": "\\)",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.quoted.other.literal.lower.crystal",
 			"patterns": [
 				{
@@ -910,18 +910,18 @@
 		},
 		{
 			"begin": "%[qwi]\\<",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "literal incapable of interpolation -- <>",
 			"end": "\\>",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.quoted.other.literal.lower.crystal",
 			"patterns": [
 				{
@@ -935,18 +935,18 @@
 		},
 		{
 			"begin": "%[qwi]\\[",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "literal incapable of interpolation -- []",
 			"end": "\\]",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.quoted.other.literal.lower.crystal",
 			"patterns": [
 				{
@@ -960,18 +960,18 @@
 		},
 		{
 			"begin": "%[qwi]\\{",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "literal incapable of interpolation -- {}",
 			"end": "\\}",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.quoted.other.literal.lower.crystal",
 			"patterns": [
 				{
@@ -985,18 +985,18 @@
 		},
 		{
 			"begin": "%[qwi]\\|",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "literal incapable of interpolation -- ||",
 			"end": "\\|",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.quoted.other.literal.lower.crystal",
 			"patterns": [
 				{
@@ -1036,19 +1036,19 @@
 		},
 		{
 			"begin": "(?><<-('?)((?:[_\\w]+_|)HTML)\\b\\1)",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "heredoc with embedded HTML and indented terminator",
 			"contentName": "text.html.embedded.crystal",
 			"end": "\\s*\\2\\b",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.unquoted.embedded.html.crystal",
 			"patterns": [
 				{
@@ -1067,19 +1067,19 @@
 		},
 		{
 			"begin": "(?><<-('?)((?:[_\\w]+_|)SQL)\\b\\1)",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "heredoc with embedded SQL and indented terminator",
 			"contentName": "text.sql.embedded.crystal",
 			"end": "\\s*\\2\\b",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.unquoted.embedded.sql.crystal",
 			"patterns": [
 				{
@@ -1098,19 +1098,19 @@
 		},
 		{
 			"begin": "(?><<-('?)((?:[_\\w]+_|)CSS)\\b\\1)",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "heredoc with embedded css and intented terminator",
 			"contentName": "text.css.embedded.crystal",
 			"end": "\\s*\\2\\b",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.unquoted.embedded.css.crystal",
 			"patterns": [
 				{
@@ -1129,19 +1129,19 @@
 		},
 		{
 			"begin": "(?><<-('?)((?:[_\\w]+_|)CPP)\\b\\1)",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "heredoc with embedded c++ and intented terminator",
 			"contentName": "text.c++.embedded.crystal",
 			"end": "\\s*\\2\\b",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.unquoted.embedded.cplusplus.crystal",
 			"patterns": [
 				{
@@ -1160,19 +1160,19 @@
 		},
 		{
 			"begin": "(?><<-('?)((?:[_\\w]+_|)C)\\b\\1)",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "heredoc with embedded c++ and intented terminator",
 			"contentName": "text.c.embedded.crystal",
 			"end": "\\s*\\2\\b",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.unquoted.embedded.c.crystal",
 			"patterns": [
 				{
@@ -1191,19 +1191,19 @@
 		},
 		{
 			"begin": "(?><<-('?)((?:[_\\w]+_|)(?:JS|JAVASCRIPT))\\b\\1)",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "heredoc with embedded javascript and intented terminator",
 			"contentName": "text.js.embedded.crystal",
 			"end": "\\s*\\2\\b",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.unquoted.embedded.js.crystal",
 			"patterns": [
 				{
@@ -1222,19 +1222,19 @@
 		},
 		{
 			"begin": "(?><<-('?)((?:[_\\w]+_|)JQUERY)\\b\\1)",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "heredoc with embedded javascript and intented terminator",
 			"contentName": "text.js.jquery.embedded.crystal",
 			"end": "\\s*\\2\\b",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.unquoted.embedded.js.jquery.crystal",
 			"patterns": [
 				{
@@ -1253,19 +1253,19 @@
 		},
 		{
 			"begin": "(?><<-('?)((?:[_\\w]+_|)(?:SH|SHELL))\\b\\1)",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "heredoc with embedded shell and intented terminator",
 			"contentName": "text.shell.embedded.crystal",
 			"end": "\\s*\\2\\b",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.unquoted.embedded.shell.crystal",
 			"patterns": [
 				{
@@ -1284,19 +1284,19 @@
 		},
 		{
 			"begin": "(?><<-('?)((?:[_\\w]+_|)CRYSTAL)\\b\\1)",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "heredoc with embedded crystal and intented terminator",
 			"contentName": "text.crystal.embedded.crystal",
 			"end": "\\s*\\2\\b",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.unquoted.embedded.crystal.crystal",
 			"patterns": [
 				{
@@ -1315,18 +1315,18 @@
 		},
 		{
 			"begin": "(?><<-'(\\w+)')",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "heredoc with indented terminator",
 			"end": "\\s*\\1\\b",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.unquoted.heredoc.crystal",
 			"patterns": [
 				{
@@ -1339,18 +1339,18 @@
 		},
 		{
 			"begin": "(?><<-(\\w+)\\b)",
-			"beginCaptures": [
-				{
+			"beginCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.begin.crystal"
 				}
-			],
+			},
 			"comment": "heredoc with indented terminator",
 			"end": "\\s*\\1\\b",
-			"endCaptures": [
-				{
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.string.end.crystal"
 				}
-			],
+			},
 			"name": "string.unquoted.heredoc.crystal",
 			"patterns": [
 				{
@@ -1583,11 +1583,11 @@
 		},
 		"nest_brackets": {
 			"begin": "\\[",
-			"captures": [
-				{
+			"captures": {
+				"0": {
 					"name": "punctuation.section.scope.crystal"
 				}
-			],
+			},
 			"end": "\\]",
 			"patterns": [
 				{
@@ -1597,11 +1597,11 @@
 		},
 		"nest_brackets_i": {
 			"begin": "\\[",
-			"captures": [
-				{
+			"captures": {
+				"0": {
 					"name": "punctuation.section.scope.crystal"
 				}
-			],
+			},
 			"end": "\\]",
 			"patterns": [
 				{
@@ -1617,11 +1617,11 @@
 		},
 		"nest_brackets_r": {
 			"begin": "\\[",
-			"captures": [
-				{
+			"captures": {
+				"0": {
 					"name": "punctuation.section.scope.crystal"
 				}
-			],
+			},
 			"end": "\\]",
 			"patterns": [
 				{
@@ -1634,11 +1634,11 @@
 		},
 		"nest_curly": {
 			"begin": "\\{",
-			"captures": [
-				{
+			"captures": {
+				"0": {
 					"name": "punctuation.section.scope.crystal"
 				}
-			],
+			},
 			"end": "\\}",
 			"patterns": [
 				{
@@ -1650,11 +1650,11 @@
 			"patterns": [
 				{
 					"begin": "\\{",
-					"captures": [
-						{
+					"captures": {
+						"0": {
 							"name": "punctuation.section.scope.crystal"
 						}
-					],
+					},
 					"end": "\\}",
 					"patterns": [
 						{
@@ -1669,11 +1669,11 @@
 		},
 		"nest_curly_i": {
 			"begin": "\\{",
-			"captures": [
-				{
+			"captures": {
+				"0": {
 					"name": "punctuation.section.scope.crystal"
 				}
-			],
+			},
 			"end": "\\}",
 			"patterns": [
 				{
@@ -1689,11 +1689,11 @@
 		},
 		"nest_curly_r": {
 			"begin": "\\{",
-			"captures": [
-				{
+			"captures": {
+				"0": {
 					"name": "punctuation.section.scope.crystal"
 				}
-			],
+			},
 			"end": "\\}",
 			"patterns": [
 				{
@@ -1706,11 +1706,11 @@
 		},
 		"nest_ltgt": {
 			"begin": "\\<",
-			"captures": [
-				{
+			"captures": {
+				"0": {
 					"name": "punctuation.section.scope.crystal"
 				}
-			],
+			},
 			"end": "\\>",
 			"patterns": [
 				{
@@ -1720,11 +1720,11 @@
 		},
 		"nest_ltgt_i": {
 			"begin": "\\<",
-			"captures": [
-				{
+			"captures": {
+				"0": {
 					"name": "punctuation.section.scope.crystal"
 				}
-			],
+			},
 			"end": "\\>",
 			"patterns": [
 				{
@@ -1740,11 +1740,11 @@
 		},
 		"nest_ltgt_r": {
 			"begin": "\\<",
-			"captures": [
-				{
+			"captures": {
+				"0": {
 					"name": "punctuation.section.scope.crystal"
 				}
-			],
+			},
 			"end": "\\>",
 			"patterns": [
 				{
@@ -1757,11 +1757,11 @@
 		},
 		"nest_parens": {
 			"begin": "\\(",
-			"captures": [
-				{
+			"captures": {
+				"0": {
 					"name": "punctuation.section.scope.crystal"
 				}
-			],
+			},
 			"end": "\\)",
 			"patterns": [
 				{
@@ -1771,11 +1771,11 @@
 		},
 		"nest_parens_i": {
 			"begin": "\\(",
-			"captures": [
-				{
+			"captures": {
+				"0": {
 					"name": "punctuation.section.scope.crystal"
 				}
-			],
+			},
 			"end": "\\)",
 			"patterns": [
 				{
@@ -1791,11 +1791,11 @@
 		},
 		"nest_parens_r": {
 			"begin": "\\(",
-			"captures": [
-				{
+			"captures": {
+				"0": {
 					"name": "punctuation.section.scope.crystal"
 				}
-			],
+			},
 			"end": "\\)",
 			"patterns": [
 				{
@@ -1843,11 +1843,11 @@
 				},
 				{
 					"begin": "\\(",
-					"captures": [
-						{
+					"captures": {
+						"0": {
 							"name": "punctuation.definition.group.crystal"
 						}
-					],
+					},
 					"end": "\\)",
 					"name": "string.regexp.group.crystal",
 					"patterns": [

--- a/syntaxes/crystal.json
+++ b/syntaxes/crystal.json
@@ -1465,12 +1465,6 @@
 			"name": "meta.function-call.crystal",
 			"patterns": [
 				{
-					"include": "#nest_function_parens"
-				},
-				{
-					"include": "#known_function_names"
-				},
-				{
 					"match": "([a-zA-Z0-9_!?]+)(?=\\()",
 					"name": "entity.name.function.crystal"
 				},


### PR DESCRIPTION
technically the current source works in VSCode only because JavaScript's indexing "works" by string coercion.  in the TextMate structure these have to be maps with integer keys

additionally, there were two includes which did not properly resolve.  we're not sure what these were supposed to point to, so we removed them

we made these changes to make it work with another editor which uses similar grammar structures: https://github.com/asottile/babi