### PR TITLE
Add macro expansion on hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,11 @@
 					"default": false,
 					"description": "Show symbol information when mouse is hover."
 				},
+				"crystal-lang.macroExpansionHover": {
+					"type": "boolean",
+					"default": false,
+					"description": "Show macro expansion when mouse hovers over a macro."
+				},
 				"crystal-lang.completion": {
 					"type": "boolean",
 					"default": false,

--- a/package.json
+++ b/package.json
@@ -220,6 +220,20 @@
 					"description": "[Reload required]\nEnables support for Windows Subsystem Linux."
 				}
 			}
+		},
+		"commands": [
+			{
+				"command": "crystal-lang.showMacroExpansion",
+				"title": "Show macro expansion"
+			}
+		],
+		"menus": {
+			"editor/context": [
+				{
+					"command": "crystal-lang.showMacroExpansion",
+					"group": "z_commands"
+				}
+			]
 		}
 	},
 	"scripts": {

--- a/src/crystalMacro.ts
+++ b/src/crystalMacro.ts
@@ -1,0 +1,61 @@
+import * as vscode from "vscode";
+import { spawnSync } from 'node:child_process';
+
+export async function registerCrystalMacroHoverProvider(context: vscode.ExtensionContext) {
+    vscode.languages.registerHoverProvider({ scheme: 'file', language: 'crystal' }, {
+        provideHover(document, position, token) {
+            return expandMacroToHover(document, position);
+        }
+    })
+}
+
+function expandMacroToHover(document: vscode.TextDocument, position: vscode.Position): vscode.Hover {
+    const config = vscode.workspace.getConfiguration("crystal-lang")
+    if (!config["macroExpansionHover"]) {
+        return;
+    }
+
+    let currentWorkspacePath = vscode.workspace.getWorkspaceFolder(document.uri).uri.path
+
+    let documentPath = document.uri.path;
+    let line = position.line + 1;
+    let column = position.character + 1;
+
+    let expandArgs: string[] = ['tool', 'expand']
+
+    let mainFile = '';
+    if (config["mainFile"]) {
+        mainFile = config["mainFile"].replace("${workspaceRoot}", currentWorkspacePath)
+
+        if (mainFile !== documentPath) {
+            expandArgs.push(mainFile)
+        }
+    }
+
+    expandArgs.push(documentPath, '--cursor', `${documentPath}:${line}:${column}`)
+
+    let result = spawnSync(
+        config["compiler"], expandArgs,
+        { cwd: currentWorkspacePath }
+    );
+
+    if (result.status !== 0) {
+        console.error(result.stderr.toString());
+        return;
+    }
+
+    let stdout = result.output.join('\n').replace(/^\n+|\n+$/g, '');
+    if (stdout.startsWith("no expansion found")) {
+        // console.log(`No macro expansion at ${filePath}:${line}:${column}`)
+        return;
+    }
+
+    let markdownResult = new vscode.MarkdownString("```\n" + stdout + "\n```");
+
+    let lineText = document.lineAt(position).text;
+    let lineStart = document.offsetAt(new vscode.Position(position.line, 0));
+    let lineEnd = lineStart + lineText.length;
+    let range = new vscode.Range(document.positionAt(lineStart), document.positionAt(lineEnd));
+
+    return new vscode.Hover(markdownResult, range)
+}

--- a/src/crystalMacro.ts
+++ b/src/crystalMacro.ts
@@ -2,18 +2,39 @@ import * as vscode from "vscode";
 import { spawnSync } from 'node:child_process';
 
 export async function registerCrystalMacroHoverProvider(context: vscode.ExtensionContext) {
+    let macroExpansionChannel = vscode.window.createOutputChannel("Crystal Macro Expansion", "crystal")
+
     vscode.languages.registerHoverProvider({ scheme: 'file', language: 'crystal' }, {
         provideHover(document, position, token) {
             return expandMacroToHover(document, position);
         }
     })
+
+    vscode.commands.registerCommand('crystal-lang.showMacroExpansion', function() {
+        const activeEditor = vscode.window.activeTextEditor;
+        const document = activeEditor.document;
+        const position = activeEditor.selection.active;
+        const positionString = `${document.uri.path}:${position.line + 1}:${position.character + 1}`;
+
+        let stdout = execExpandMacro(document, position)
+
+        if (stdout === undefined || stdout === "") {
+            return;
+        }
+
+        if (stdout.startsWith("no expansion found")) {
+            stdout = `# No macro expansion for ${positionString}`;
+        } else {
+            stdout = `# Macro expansion for ${positionString}:\n\n${stdout}\n`
+        }
+
+        macroExpansionChannel.appendLine(stdout)
+        macroExpansionChannel.show()
+    })
 }
 
-function expandMacroToHover(document: vscode.TextDocument, position: vscode.Position): vscode.Hover {
+function execExpandMacro(document: vscode.TextDocument, position: vscode.Position): string {
     const config = vscode.workspace.getConfiguration("crystal-lang")
-    if (!config["macroExpansionHover"]) {
-        return;
-    }
 
     let currentWorkspacePath = vscode.workspace.getWorkspaceFolder(document.uri).uri.path
 
@@ -45,8 +66,19 @@ function expandMacroToHover(document: vscode.TextDocument, position: vscode.Posi
     }
 
     let stdout = result.output.join('\n').replace(/^\n+|\n+$/g, '');
+
+    return stdout
+}
+
+function expandMacroToHover(document: vscode.TextDocument, position: vscode.Position): vscode.Hover {
+    const config = vscode.workspace.getConfiguration("crystal-lang")
+    if (!config["macroExpansionHover"]) {
+        return;
+    }
+
+    let stdout = execExpandMacro(document, position)
+
     if (stdout.startsWith("no expansion found")) {
-        // console.log(`No macro expansion at ${filePath}:${line}:${column}`)
         return;
     }
 

--- a/src/crystalMain.ts
+++ b/src/crystalMain.ts
@@ -10,6 +10,7 @@ import { CrystalDocumentSymbolProvider } from "./crystalSymbols"
 import { CrystalCompletionItemProvider } from "./crystalCompletion"
 import { CrystalImplementationsProvider } from "./crystalImplementations"
 import { registerCrystalTask } from "./crystalTasks"
+import { registerCrystalMacroHoverProvider } from "./crystalMacro"
 
 // Language configuration for identation and patterns. Based on vscode-ruby
 const crystalConfiguration = {
@@ -46,6 +47,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// Register Tasks
 	registerCrystalTask(context)
+
+	registerCrystalMacroHoverProvider(context)
 
 	// Detect server and set configuration
 	let scry = config["server"]


### PR DESCRIPTION
When enabled, when the cursor hovers over a macro, the file/line is sent to `crystal tool expand` and the results are returned in a hover.

Closes #4.

## Simple example

Macros defined in `src/mlcsim/transcoder.cr`:
![image](https://github.com/crystal-lang-tools/vscode-crystal-lang/assets/32797552/e8b83e00-3089-40d9-b11d-04a514fe352e)

Main file set to `src/mlcsim.cr`:
![image](https://github.com/crystal-lang-tools/vscode-crystal-lang/assets/32797552/1c44aac4-3096-4c99-8629-1837a409af7c)

Macro expansion on hover in `spec/mlcsim/matrix_spec.cr`:
![Screenshot_2023-05-19_02-39-18](https://github.com/crystal-lang-tools/vscode-crystal-lang/assets/32797552/bdab6bb8-4e1a-4970-88dc-6ab91ad4be4d)
