### PR TITLE
Add support for Crystal syntax highlighting in Markdown code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
 					".slang"
 				],
 				"configuration": "./slang-configuration.json"
+			},
+			{
+				"id": "crystal-markdown-injection"
 			}
 		],
 		"grammars": [
@@ -83,6 +86,17 @@
 				"language": "slang",
 				"scopeName": "text.slang",
 				"path": "./syntaxes/slang.json"
+			},
+			{
+				"language": "crystal-markdown-injection",
+				"scopeName": "markdown.crystal.codeblock",
+				"path": "./syntaxes/codeblock.json",
+				"injectTo": [
+					"text.html.markdown"
+				],
+				"embeddedLanguages": {
+					"meta.embedded.block.crystal": "crystal"
+				}
 			}
 		],
 		"snippets": [

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -1,0 +1,45 @@
+{
+    "fileTypes": [],
+    "injectionSelector": "L:text.html.markdown",
+    "patterns": [
+        {
+            "include": "#superjs-code-block"
+        }
+    ],
+    "repository": {
+        "superjs-code-block": {
+            "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(crystal|cr)(\\s+[^`~]*)?$)",
+            "name": "markup.fenced_code.block.markdown",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "beginCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                },
+                "4": {
+                    "name": "fenced_code.block.language.markdown"
+                },
+                "5": {
+                    "name": "fenced_code.block.language.attributes.markdown"
+                }
+            },
+            "endCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                }
+            },
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.crystal",
+                    "patterns": [
+                        {
+                            "include": "source.crystal"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "scopeName": "markdown.crystal.codeblock"
+}


### PR DESCRIPTION
Closes #56 .

Adds an injection grammar for Crystal within Markdown code blocks. Can either use `cr` or `crystal`.

![image](https://github.com/crystal-lang-tools/vscode-crystal-lang/assets/32797552/727a91d0-e060-471b-86d6-9c055806ed16)

Used code from [here](https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example).
