### PR TITLE
v0.9.4: Add configuration option to disable the GC for the compiler tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.9.4] - 2024-05-16
+
+### Add
+
+- Add configuration option `crystal-lang.disable-gc` to disable the garbage collector when running compiler tools.
+
 ## [0.9.3] - 2024-03-01
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ For debugging support, it's recommended to follow the guide [here](https://dev.t
 - `shards` - set a custom absolute path for the shards executable
 - `spec-explorer` - enable the built-in testing UI for specs, recommended for Crystal >= 1.11 due to `--dry-run` flag (reload required)
 - `spec-tags` - specific tags to pass to the spec runner
+- `disable-gc` - disable the garbage collector when running compiler tools, can provide increased performance at the cost of increased memory usage, defaults to false
 
 By default, the problems runner, hover provider, and definitions provider are turned on. This may not be ideal for larger projects due to compile times and memory usage, so it is recommended to turn them off in the vscode settings. That can be done per-project by creating a `.vscode/settings.json` file with:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "crystal-lang",
-	"version": "0.9.3",
+	"version": "0.9.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "crystal-lang",
-			"version": "0.9.3",
+			"version": "0.9.4",
 			"license": "MIT",
 			"dependencies": {
 				"async-mutex": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "crystal-lang",
 	"displayName": "Crystal Language",
 	"description": "The Crystal Programming Language",
-	"version": "0.9.3",
+	"version": "0.9.4",
 	"publisher": "crystal-lang-tools",
 	"icon": "images/icon.gif",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -207,6 +207,11 @@
 					"type": "string",
 					"default": "",
 					"description": "Compile-time flags to pass to the compiler, i.e. '-Dflag1 -Dflag2'.\nFlags are shared across multi-root workspaces."
+				},
+				"crystal-lang.disable-gc": {
+					"type": "boolean",
+					"default": false,
+					"description": "Disable garbage collection for running the compiler tools. Can improve performance at the expense of memory."
 				}
 			}
 		},

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -34,7 +34,11 @@ function execWrapper(
 	) => void
 ): ChildProcess {
 	const disable_gc = workspace.getConfiguration('crystal-lang').get<boolean>('disable-gc', false);
-	const env = { ...process.env, 'GC_DONT_GC': disable_gc ? '1' : '0' }
+	const env = { ...process.env }
+
+	if (disable_gc) {
+		env['GC_DONT_GC'] = '1'
+	}
 
 	const response = exec(command, { 'cwd': cwd, env }, (err, stdout, stderr) => {
 		if (err) {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -33,7 +33,10 @@ function execWrapper(
 		stderr: string
 	) => void
 ): ChildProcess {
-	const response = exec(command, { 'cwd': cwd }, (err, stdout, stderr) => {
+	const disable_gc = workspace.getConfiguration('crystal-lang').get<boolean>('disable-gc', false);
+	const env = { ...process.env, 'GC_DONT_GC': disable_gc ? '1' : '0' }
+
+	const response = exec(command, { 'cwd': cwd, env }, (err, stdout, stderr) => {
 		if (err) {
 			callback({ ...err, stderr, stdout }, stdout, stderr);
 			return;


### PR DESCRIPTION
This allows for greater performance at the cost of memory. Defaults to off due to the significant RAM usage increase.