### PR TITLE
v0.9.5 - server-env config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.9.5] - 2024-07-05
+
+### Add
+
+- Add configuration option `crystal-lang.server-env` for adding environment variables to be passed to the LSP
+
 ## [0.9.4] - 2024-05-16
 
 ### Add

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ For debugging support, it's recommended to follow the guide [here](https://dev.t
 - `main` - set a main executable to use for the current project (`${workspaceRoot}/src/main.cr`)
 - `problems` - runs the compiler on save and reports any issues (reload required)
 - `server` - absolute path to an LSP executable to use instead of the custom features provided by this extension, like [Crystalline](https://github.com/elbywan/crystalline) (reload required)
+- `server-env` - object defining env variables to pass to the LSP (reload required)
 - `shards` - set a custom absolute path for the shards executable
 - `spec-explorer` - enable the built-in testing UI for specs, recommended for Crystal >= 1.11 due to `--dry-run` flag (reload required)
 - `spec-tags` - specific tags to pass to the spec runner

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "crystal-lang",
-	"version": "0.9.4",
+	"version": "0.9.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "crystal-lang",
-			"version": "0.9.4",
+			"version": "0.9.5",
 			"license": "MIT",
 			"dependencies": {
 				"async-mutex": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "crystal-lang",
 	"displayName": "Crystal Language",
 	"description": "The Crystal Programming Language",
-	"version": "0.9.4",
+	"version": "0.9.5",
 	"publisher": "crystal-lang-tools",
 	"icon": "images/icon.gif",
 	"license": "MIT",
@@ -167,6 +167,11 @@
 					"type": "string",
 					"default": "",
 					"description": "[Experimental][Reload required]\nAbsolute path for Scry/Crystalline LSP server binary\n(Language Server Protocol for Crystal)."
+				},
+				"crystal-lang.server-env": {
+					"type": "object",
+					"default": {},
+					"description": "[Experimental][Reload required]\nEnvironment object to pass to the LSP"
 				},
 				"crystal-lang.main": {
 					"type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,8 +60,17 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
 	if (existsSync(lsp)) {
 		crystalOutputChannel.appendLine(`[Crystal] loading lsp ${lsp}`)
+		const server_env = config["server-env"]
 
-		let serverOptions: ServerOptions = { command: lsp, args: [] }
+		let serverOptions: ServerOptions = {
+			command: lsp,
+			args: []
+		}
+
+		if (server_env) {
+			serverOptions.options = { env: { ...process.env, ...server_env } }
+		}
+
 		let clientOptions: LanguageClientOptions = {
 			documentSelector: selector,
 			synchronize: {


### PR DESCRIPTION
## [0.9.5] - 2024-07-05

### Add

- Add configuration option `crystal-lang.server-env` for adding environment variables to be passed to the LSP