### PR TITLE
handle response of "crystal tool context"

### DIFF
--- a/src/hover.ts
+++ b/src/hover.ts
@@ -278,6 +278,7 @@ async function spawnContextTool(
 
 	return await execAsync(cmd, folder.uri.fsPath)
 		.then((response) => {
+			response = response.replace(/^start\n/, "");
 			findProblems(response, document.uri);
 			return JSON.parse(response);
 		}).catch((err) => {


### PR DESCRIPTION
Response of `crystal tool context` seems to include string "start".
This prevent to parse as JSON.

Maybe this fixes #185.
