### PR TITLE
Fallback to $CRYSTAL_LSP_PATH if resolution for config.server fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For debugging support, it's recommended to follow the guide [here](https://dev.t
 - `hover` - show type information on hover (reload required)
 - `main` - set a main executable to use for the current project (`${workspaceRoot}/src/main.cr`)
 - `problems` - runs the compiler on save and reports any issues (reload required)
-- `server` - absolute path to an LSP executable to use instead of the custom features provided by this extension, like [Crystalline](https://github.com/elbywan/crystalline) (reload required)
+- `server` - absolute path to an LSP executable to use instead of the custom features provided by this extension, like [Crystalline](https://github.com/elbywan/crystalline) (reload required). If empty, fallback to `$CRYSTAL_LSP_PATH`
 - `server-env` - object defining env variables to pass to the LSP (reload required)
 - `shards` - set a custom absolute path for the shards executable
 - `spec-explorer` - enable the built-in testing UI for specs, recommended for Crystal >= 1.11 due to `--dry-run` flag (reload required)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,7 +39,7 @@ let lsp_client: LanguageClient
 
 export async function activate(context: ExtensionContext): Promise<void> {
 	const config = workspace.getConfiguration("crystal-lang");
-	const lsp = config["server"]
+	const lsp = config["server"] || process.env.CRYSTAL_LSP_PATH
 
 	// Specs enabled regardless of LSP support
 	if (config["spec-explorer"]) new CrystalTestingProvider();


### PR DESCRIPTION
This PR proposes an additional way to configure the LSP path.
I'd like to set up development tools on a per-repository basis, as different repositories may use different versions of Crystal and Crystalline.
Supporting the current $PATH or allowing a custom environment variable would be more flexible and helpful than relying on an absolute path in the configuration.

[typos-lsp provides same feature](https://github.com/tekumara/typos-lsp/blob/e5bc8789e5d03e4e7a388d6b53559249b248fc11/src/extension.ts#L122)